### PR TITLE
Change declare syntax

### DIFF
--- a/src/backend/c-lisp.py
+++ b/src/backend/c-lisp.py
@@ -218,10 +218,10 @@ class BrilispCodeGenerator:
         return stmt[0] == "declare"
 
     def gen_decl_stmt(self, stmt):
-        if not (len(stmt) == 2 and len(stmt[1]) == 2):
+        if not len(stmt) == 3:
             raise CodegenError(f"bad declare statement: {stmt}")
 
-        name, typ = stmt[1]
+        name, typ = stmt[1], stmt[2]
         scoped_name = self.construct_scoped_name(name, self.scopes)
         if scoped_name in self.symbol_types:
             raise CodegenError(f"Re-declaration of variable {name}")

--- a/src/backend/tests/c-lisp/array-sum.sexp
+++ b/src/backend/tests/c-lisp/array-sum.sexp
@@ -2,8 +2,8 @@
     (define ((print int) (n int)))
 
     (define ((arr_sum int) (a (ptr int)) (n int))
-        (declare (i int))
-        (declare (sum int))
+        (declare i int)
+        (declare sum int)
         (set sum 0)
 
         (for ((set i 0)
@@ -13,9 +13,9 @@
         (ret sum))
 
     (define ((main void))
-        (declare (arr1 (ptr int)))
-        (declare (arr2 (ptr int)))
-        (declare (i int))
+        (declare arr1 (ptr int))
+        (declare arr2 (ptr int))
+        (declare i int)
 
         (set arr1 (alloc int 10))
         (set arr2 (alloc int 10))
@@ -23,7 +23,7 @@
         (for ((set i 0)
               (lt i 10)
               (set i (add i 1)))
-            (declare (arr_i (ptr int)))
+            (declare arr_i (ptr int))
             (set arr_i (ptradd arr1 i))
             (store arr_i i)
             (set arr_i (ptradd arr2 i))

--- a/src/backend/tests/c-lisp/binary-ops.sexp
+++ b/src/backend/tests/c-lisp/binary-ops.sexp
@@ -2,9 +2,9 @@
     (define ((print int) (n int)))
 
     (define ((main int))
-        (declare (five int))
-        (declare (twenty int))
-        (declare (res bool))
+        (declare five int)
+        (declare twenty int)
+        (declare res bool)
 
         (set five 5)
         (set twenty 20)

--- a/src/backend/tests/c-lisp/bisection-rootfind.sexp
+++ b/src/backend/tests/c-lisp/bisection-rootfind.sexp
@@ -2,7 +2,7 @@
     (define ((fprint float) (n float)))
 
     (define ((quad-val float) (a2 float) (a1 float) (a0 float) (x float))
-        (declare (val float))
+        (declare val float)
         (set val a0)
         (set val (fadd val (fmul a1 x)))
         (set val (fadd val (fmul a2 (fmul x x))))
@@ -12,12 +12,12 @@
              (a2 float) (a1 float) (a0 float) ; The quadratic equation is a2(x^2) + a1(x) + a0 = 0
              (neg-pt float) (pos-pt float))   ; Known to be > 0 at pos-pt and < 0 at neg-pt
 
-            (declare (prev-mid-val float))
+            (declare prev-mid-val float)
             (set prev-mid-val 0.0)
 
-            (declare (mid-val float))
-            (declare (mid-pt float))
-            (declare (loop bool))
+            (declare mid-val float)
+            (declare mid-pt float)
+            (declare loop bool)
 
             (set loop #t)
             (while loop

--- a/src/backend/tests/c-lisp/fibonacci-dynamic-prog.sexp
+++ b/src/backend/tests/c-lisp/fibonacci-dynamic-prog.sexp
@@ -2,10 +2,10 @@
     (define ((print int) (n int)))
 
     (define ((fib int) (n int))
-        (declare (last-2 int))
-        (declare (last-1 int))
-        (declare (res int))
-        (declare (i int))
+        (declare last-2 int)
+        (declare last-1 int)
+        (declare res int)
+        (declare i int)
 
         (set last-2 0)
         (set last-1 1)

--- a/src/backend/tests/c-lisp/first.sexp
+++ b/src/backend/tests/c-lisp/first.sexp
@@ -2,6 +2,6 @@
     (define ((print int) (n int)))
 
     (define ((main int))
-        (declare (res int))
+        (declare res int)
         (set res (call print 5))
         (ret 0)))

--- a/src/backend/tests/c-lisp/gaussian-elimination.sexp
+++ b/src/backend/tests/c-lisp/gaussian-elimination.sexp
@@ -6,10 +6,10 @@
     (define ((atoi int) (s (ptr int))))
 
     (define ((row-op void) (mod (ptr float)) (ref (ptr float)) (len int)) ; mod -> mod - factor*ref
-        (declare (i int))
-        (declare (mod_p (ptr float)))
-        (declare (l float))
-        (declare (pv int))
+        (declare i int)
+        (declare mod_p (ptr float))
+        (declare l float)
+        (declare pv int)
 
         (for ((set pv 0)
               (and
@@ -37,9 +37,9 @@
         (ret))
 
     (define ((gaussian-eli void) (mat (ptr float)) (nrows int) (ncols int))
-        (declare (ref-row int))
-        (declare (mod-row int))
-        (declare (col int))
+        (declare ref-row int)
+        (declare mod-row int)
+        (declare col int)
 
         (for ((set ref-row 0)
               (lt ref-row (sub nrows 1))
@@ -55,11 +55,11 @@
         (ret))
 
     (define ((main void) (argc int) (argv (ptr (ptr int))))
-        (declare (input (ptr float)))
-        (declare (nr int))
-        (declare (nc int))
-        (declare (sz int))
-        (declare (i int))
+        (declare input (ptr float))
+        (declare nr int)
+        (declare nc int)
+        (declare sz int)
+        (declare i int)
 
         (set nr (call atoi (load (ptradd argv 1))))
         (set nc (call atoi (load (ptradd argv 2))))

--- a/src/backend/tests/c-lisp/insertion-sort.sexp
+++ b/src/backend/tests/c-lisp/insertion-sort.sexp
@@ -5,15 +5,15 @@
     (define ((atoi int) (s (ptr int))))
 
     (define ((swap void) (a (ptr int)) (b (ptr int)))
-        (declare (tmp int))
+        (declare tmp int)
         (set tmp (load b))
         (store b (load a))
         (store a tmp)
         (ret))
 
     (define ((min int) (arr (ptr int)) (n int))
-        (declare (i int))
-        (declare (idx int))
+        (declare i int)
+        (declare idx int)
 
         (set idx 0)
         (for ((set i 1)
@@ -24,9 +24,9 @@
         (ret idx))
 
     (define ((insertion-sort void) (arr (ptr int)) (len int))
-        (declare (min-idx int))
-        (declare (i int))
-        (declare (rest-arr (ptr int)))
+        (declare min-idx int)
+        (declare i int)
+        (declare rest-arr (ptr int))
 
         (for ((set i 0)
               (lt i (sub len 1))
@@ -40,9 +40,9 @@
         (ret))
 
     (define ((main void) (argc int) (argv (ptr (ptr int))))
-        (declare (input (ptr int)))
-        (declare (len int))
-        (declare (i int))
+        (declare input (ptr int))
+        (declare len int)
+        (declare i int)
 
         (set len (sub argc 1))
         (set input (alloc int len))

--- a/src/backend/tests/c-lisp/iteration.sexp
+++ b/src/backend/tests/c-lisp/iteration.sexp
@@ -2,7 +2,7 @@
     (define ((print int) (n int)))
 
     (define ((main int))
-        (declare (i int))
+        (declare i int)
 
         (for ((set i 11)
               (lt i 11)

--- a/src/backend/tests/c-lisp/matrix-sum.sexp
+++ b/src/backend/tests/c-lisp/matrix-sum.sexp
@@ -7,8 +7,8 @@
         (ret (add (mul i len) j)))
 
     (define ((mat-cons void) (arr (ptr int)) (len int))
-        (declare (i int))
-        (declare (j int))
+        (declare i int)
+        (declare j int)
 
         (for ((set i 0)
               (lt i len)
@@ -22,11 +22,11 @@
         (ret))
 
     (define ((mat-add (ptr int)) (a (ptr int)) (b (ptr int)) (len int))
-        (declare (i int))
-        (declare (j int))
-        (declare (idx int))
+        (declare i int)
+        (declare j int)
+        (declare idx int)
 
-        (declare (res (ptr int)))
+        (declare res (ptr int))
         (set res (call malloc (mul (mul len len) 4)))
 
         (for ((set i 0)
@@ -44,9 +44,9 @@
         (ret res))
 
     (define ((main void))
-        (declare (in1 (ptr int)))
-        (declare (in2 (ptr int)))
-        (declare (out (ptr int)))
+        (declare in1 (ptr int))
+        (declare in2 (ptr int))
+        (declare out (ptr int))
 
         (set in1 (alloc int 16))
         (call mat-cons in1 4)
@@ -55,7 +55,7 @@
 
         (set out (call mat-add in1 in2 4))
 
-        (declare (i int))
+        (declare i int)
         (for ((set i 0)
               (lt i 16)
               (set i (add i 1)))

--- a/src/backend/tests/c-lisp/prime.sexp
+++ b/src/backend/tests/c-lisp/prime.sexp
@@ -4,8 +4,8 @@
         (ret (mul i i)))
 
     (define ((gcd int) (a int) (b int))
-        (declare (big int))
-        (declare (small int))
+        (declare big int)
+        (declare small int)
 
         (if (gt a b)
             ((set big a)
@@ -20,9 +20,9 @@
         (ret (call gcd small (sub big small))))
 
     (define ((is-prime bool) (n int))
-        (declare (i int))
-        (declare (iter int))
-        (declare (not-prime bool))
+        (declare i int)
+        (declare iter int)
+        (declare not-prime bool)
         (set not-prime #f)
 
         (for ((set i 2) (le (call square i) n) (set i (add i 1)))

--- a/src/backend/tests/c-lisp/scope.sexp
+++ b/src/backend/tests/c-lisp/scope.sexp
@@ -2,17 +2,17 @@
     (define ((print int) (n int)))
 
     (define ((main void))
-        (declare (sum1 int))
+        (declare sum1 int)
         (set sum1 0)
-        (declare (sum2 int))
+        (declare sum2 int)
         (set sum2 0)
 
-        (declare (same-name int))
+        (declare same-name int)
 
         (for ((set same-name 0)
               (lt same-name 10)
               (set same-name (add same-name 1)))
-            ((declare (same-name int))
+            ((declare same-name int)
              (set same-name 0)
              (set sum2 (add sum2 same-name)))
             (set sum1 (add sum1 same-name)))

--- a/src/backend/tests/c-lisp/sum-square-difference.sexp
+++ b/src/backend/tests/c-lisp/sum-square-difference.sexp
@@ -2,12 +2,12 @@
     (define ((print int) (n int)))
 
     (define ((sum-square-diff int) (n int))
-        (declare (sum-sq int))
+        (declare sum-sq int)
         (set sum-sq 0)
-        (declare (sum int))
+        (declare sum int)
         (set sum 0)
 
-        (declare (i int))
+        (declare i int)
         (for ((set i 1) (le i n) (set i (add i 1)))
             (set sum-sq (add sum-sq (mul i i)))
             (set sum (add sum i)))

--- a/src/backend/tests/c-lisp/transpose.sexp
+++ b/src/backend/tests/c-lisp/transpose.sexp
@@ -2,7 +2,7 @@
     (define ((print int) (n int)))
 
     (define ((swap void) (a (ptr int)) (b (ptr int)))
-        (declare (tmp int))
+        (declare tmp int)
         (set tmp (load b))
         (store b (load a))
         (store a tmp)
@@ -12,8 +12,8 @@
         (ret (add (mul i len) j)))
 
     (define ((transpose void) (mat (ptr int)) (len int))
-        (declare (i int))
-        (declare (j int))
+        (declare i int)
+        (declare j int)
 
         (for ((set i 0)
               (lt i len)
@@ -25,8 +25,8 @@
         (ret))
 
     (define ((mat-cons void) (arr (ptr int)) (len int))
-        (declare (i int))
-        (declare (j int))
+        (declare i int)
+        (declare j int)
 
         (for ((set i 0)
               (lt i len)
@@ -40,7 +40,7 @@
         (ret))
 
     (define ((arr-print void) (arr (ptr int)) (len int))
-        (declare (i int))
+        (declare i int)
 
         (for ((set i 0)
               (lt i len)
@@ -49,7 +49,7 @@
         (ret))
 
     (define ((main void))
-        (declare (input (ptr int)))
+        (declare input (ptr int))
 
         (set input (alloc int 25))
         (call mat-cons input 5)


### PR DESCRIPTION
Link to the issue .
https://github.com/chsasank/llama.lisp/issues/55
We have the instruction (set a 10), (add a b), (fmul a b). But the instruction declare is defined as (declare (a int)) . Why do we require an additional () after declare. It does not add any features and is counter intuitive. Instead I propose a change in syntax which is intuitive and simple (declare a int).
So in the directory llama.lisp/src/backend/tests/c-lisp I have made changes to the syntax of all the declare statement from (declare (a b)) to (declare a b).
In the file src/backend/c-lisp.py, I have made changes to how the declare statement is interpreted.