### PR TITLE
Bindings generation from C header files

### DIFF
--- a/src/backend/tests/bindings/README.md
+++ b/src/backend/tests/bindings/README.md
@@ -1,0 +1,56 @@
+# C bindings generation for C-Lisp
+
+This is an effort to automate the process of generating bindings to libraries
+using their C header files. Parsing and resolving types is offloaded to
+Clang/LLVM, while [`gen_bindings.py`](./gen_bindings.py) maps LLVM types to C-Lisp
+types and exposes the binding generation machinery via C-Lisp macros.
+
+At the moment, support exists for inclusion of functions that use built-in
+C types. Of course, types that can't be expressed as C-Lisp types cannot be used.
+
+## How it works
+The process is as follows:
+* A C program that uses the desired functions is generated
+* The C program above is compiled to LLVM IR using CLang
+* The resulting LLVM IR is parsed using [`LLVMLite's binding layer`](https://llvmlite.readthedocs.io/en/latest/user-guide/binding/index.html)
+
+Such a process saves the complication of resolving types that use the higher-level
+features of C that don't exist in C-Lisp, such as `typedef`, `enum`, etc.
+
+## Usage in a C-Lisp program
+`gen_bindings.py` provides the `include` macro for function inclusion. `include` takes
+2 arguments: the list of headers to include in the intermediate C program, and the list
+of functions for which to generate declarations.
+
+For example:
+
+```
+,@(include
+    (stdio.h stdlib.h string.h) ; Headers
+    (malloc puts strcpy)) ; Functions to include
+```
+
+is replaced by the declarations for `malloc`, `puts` and `strcpy`.
+
+
+## Running `gen_bindings.py` interactively
+`gen_bindings.py` can be run interactively for testing and debugging, in which case it will ask
+the user for desired headers and functions, and dump the generated C program to the console.
+
+```
+$ python ./gen_bindings
+```
+
+```
+Space-delimited list of headers to include: stdlib.h
+Space-delimited list functions to parse: malloc
+#include "stdlib.h"
+extern void pin_function(void *);
+int main () {
+    pin_function(malloc);
+}
+[['define', [['malloc', ['ptr', 'int8']], ['arg-0', 'int64']]]]
+
+```
+
+See also: [Extracting C Bindings using Clang](https://outline.von-neumann.ai/s/030e5531-946b-4caa-9d5c-3dd78e76756c)

--- a/src/backend/tests/bindings/gen_bindings.py
+++ b/src/backend/tests/bindings/gen_bindings.py
@@ -1,0 +1,115 @@
+#!/bin/python3
+
+import re
+import sys
+import subprocess
+import tempfile
+from llvmlite import binding
+
+## gen_bindings.py
+## Provides macros to include forward
+## declarations from C header files
+
+
+def gen_cprog(headers, functions):
+    """Generate the C program for binding generation"""
+
+    # C code to produce an external side-effect involving each function
+    function_pins = "\n".join(f"    pin_function({func});" for func in functions)
+    # Header inclusion
+    header_includes = "\n".join(f'#include "{header}"' for header in headers)
+
+    return "\n".join(
+        (
+            header_includes,
+            "extern void pin_function(void *);",
+            "int main () {",
+            function_pins,
+            "}",
+        )
+    )
+
+
+def get_clisp_type(typ):
+    """Map an LLVM type (str) to a C-Lisp type"""
+
+    ## Handlers for each type kind
+    def get_clisp_int_type(typ):
+        """'iXX' -> 'intXX'"""
+        width = typ[1:]
+        if width == "32":
+            width = ""
+        return f"int{width}"
+
+    def get_clisp_ptr_type(typ):
+        """'XX*' -> ['ptr', 'XX']"""
+        pointee = typ[:-1]
+        return ["ptr", get_clisp_type(pointee)]
+
+    type_map = (
+        ## Type regex -> handler function
+        (r"i[0-9]+", get_clisp_int_type),
+        (r".*\*", get_clisp_ptr_type),
+        ("void", lambda t: "void"),
+    )
+    for pattern, handler in type_map:
+        if re.fullmatch(pattern, typ):
+            return handler(typ)
+    raise Exception(f"Unknown type: {typ}")
+
+
+def gen_signature(fn_ref):
+    """Generate the signature of fn_ref (LLVMLite ValueRef)"""
+    # fn_ref is a function pointer; fn_type is the function's type
+    fn_type = fn_ref.type.element_type
+    type_elements = [get_clisp_type(str(elem)) for elem in fn_type.elements]
+    signature = [
+        "define",
+        [
+            [fn_ref.name, type_elements[0]],
+            *([f"arg-{t}", typ] for t, typ in enumerate(type_elements[1:])),
+        ],
+    ]
+    return signature
+
+
+def include(headers, functions, debug=False):
+    """
+    Macro to include given functions from given header files
+    Example usage:
+        ; Generates declarations for `malloc` and `puts`, having included stdio.h and stdlib.h
+        ,(include (stdio.h stdlib.h) (malloc puts))
+    """
+
+    tmpdir = tempfile.TemporaryDirectory()
+    cprog = f"{tmpdir.name}/binding.c"
+    llprog = f"{tmpdir.name}/binding.ll"
+
+    # Generate C program using desired functions
+    cprog_file = open(cprog, "w")
+    cprog_str = gen_cprog(headers, functions)
+    if debug:
+        print(cprog_str)
+    cprog_file.write(cprog_str)
+    cprog_file.close()
+
+    # Compile to LLVM
+    subprocess.run(f"clang -o {llprog} -emit-llvm -S {cprog}".split())
+
+    # Parse the LLVM IR and get a handle to the module
+    llprog_file = open(llprog)
+    llprog_str = llprog_file.read()
+    llmod = binding.parse_assembly(llprog_str)
+    llprog_file.close()
+
+    # Cleanup
+    tmpdir.cleanup()
+
+    # Parse signatures of desired functions
+    return [gen_signature(llmod.get_function(func)) for func in functions]
+
+
+if __name__ == "__main__":
+    headers = input("Space-delimited list of headers to include: ").split()
+    functions = input("Space-delimited list functions to parse: ").split()
+    print(include(headers, functions, debug=True))

--- a/src/backend/tests/bindings/stdlib-include.sexp
+++ b/src/backend/tests/bindings/stdlib-include.sexp
@@ -1,0 +1,10 @@
+(c-lisp
+    ,@(include
+        (stdio.h stdlib.h string.h) ; Headers
+        (malloc puts strcpy)) ; Functions to include
+
+    (define ((main void))
+        (declare buf (ptr int8))
+        (set buf (call malloc (sext 50 int64)))
+        (call strcpy buf "Brought to you by malloc, strcpy and puts")
+        (call puts buf)))

--- a/src/backend/tests/bindings/turnt.toml
+++ b/src/backend/tests/bindings/turnt.toml
@@ -1,0 +1,1 @@
+command = "guile ../../utils/sexp-json.scm < {filename} | python ../../prelisp.py gen_bindings.py | python ../../c-lisp.py | python ../../brilisp.py | python ../../llvm.py | bash ../brilisp/run.sh {args}"


### PR DESCRIPTION
This is an effort to automate the process of generating bindings to libraries using their C header files. Parsing and resolving types is offloaded to Clang/LLVM, while [`gen_bindings.py`](./gen_bindings.py) maps LLVM types to C-Lisp types and exposes the binding generation machinery via C-Lisp macros.