### PR TITLE
Code for Frigate.Lisp

### DIFF
--- a/src/app-store/definitions/frigate/frigate.lisp
+++ b/src/app-store/definitions/frigate/frigate.lisp
@@ -11,6 +11,4 @@
       (volumes
         ("/etc/localtime" "/etc/localtime:ro")
         ("./config" "/config")
-        ("./storage" "/media/frigate"))
-      (environment
-        (FRIGATE_RTSP_PASSWORD "password")))))
+        ("./storage" "/media/frigate"))))))

--- a/src/app-store/definitions/frigate/frigate.lisp
+++ b/src/app-store/definitions/frigate/frigate.lisp
@@ -1,0 +1,16 @@
+(define-app
+  (version "3.9")
+  (ports 8971 8554 8555/tcp 8555/udp)
+  (containers
+    (container
+      (name "frigate")
+      (image "ghcr.io/blakeblackshear/frigate:stable")
+      (restart "unless-stopped")
+      (devices
+        ("/dev/bus/usb" "/dev/bus/usb"))
+      (volumes
+        ("/etc/localtime" "/etc/localtime:ro")
+        ("./config" "/config")
+        ("./storage" "/media/frigate"))
+      (environment
+        (FRIGATE_RTSP_PASSWORD "password")))))


### PR DESCRIPTION
Frigate - lisp for deploying and running the frigate container using lisp commands. The frigate container container contains the version , ports, image, device and volumes which when run gives the other necessary files such as config , storage etc. which helps us integrate with local camera  which here is tapo_c200 for real time network video streaming.