### PR TITLE
Remove Bitnami containers and migrate to official Postgres/Redis images

### DIFF
--- a/src/app-store/definitions/discourse/discourse.lisp
+++ b/src/app-store/definitions/discourse/discourse.lisp
@@ -4,7 +4,7 @@
     (url "https://www.discourse.org/")
     (let ((db-user "bn_discourse")
           (db-password ,(gen-password))
-          (db-name "bitnami_discourse")
+          (db-name "postgres")
           (redis-password ,(gen-password))
           (discourse-image "docker.io/bitnami/discourse:3.3.2")
           (discourse-host ,(interactive-input "Where is this going to be deployed?" "Example: www.example.com"))
@@ -13,18 +13,18 @@
         (containers
             (container
                 (name "postgresql")
-                (image "docker.io/bitnami/postgresql:17")
+                (image "docker.io/library/postgres:17")
                 (volumes
-                    ("postgresql_data" "/bitnami/postgresql"))
+                    ("postgresql_data" "/var/lib/postgresql/data"))
                 (environment
-                    ("POSTGRESQL_USERNAME" ,db-user)
-                    ("POSTGRESQL_DATABASE" ,db-name)
-                    ("POSTGRESQL_PASSWORD" ,db-password)))
+                    ("POSTGRES_USER" ,db-user)
+                    ("POSTGRES_DB" ,db-name)
+                    ("POSTGRES_PASSWORD" ,db-password)))
             (container
                 (name "redis")
-                (image "docker.io/bitnami/redis:7.4")
+                (image "docker.io/library/redis:7.4")
                 (volumes
-                    ("redis_data" "/bitnami/redis"))
+                    ("redis_data" "/data"))
                 (environment
                     ("REDIS_PASSWORD" ,redis-password)))
             (container

--- a/src/app-store/definitions/discourse/discourse.lisp
+++ b/src/app-store/definitions/discourse/discourse.lisp
@@ -4,7 +4,7 @@
     (url "https://www.discourse.org/")
     (let ((db-user "bn_discourse")
           (db-password ,(gen-password))
-          (db-name "postgres")
+          (db-name "discourse")
           (redis-password ,(gen-password))
           (discourse-image "docker.io/bitnami/discourse:3.3.2")
           (discourse-host ,(interactive-input "Where is this going to be deployed?" "Example: www.example.com"))

--- a/src/app-store/definitions/docuseal/docuseal.lisp
+++ b/src/app-store/definitions/docuseal/docuseal.lisp
@@ -17,10 +17,10 @@
                     ("DATABASE_NAME" "docuseal")))
             (container
                 (name "postgres")
-                (image "docker.io/bitnami/postgresql:17")
+                (image "docker.io/library/postgres:17")
                 (volumes
-                    ("pg_data" "/bitnami/postgresql"))
+                    ("pg_data" "/var/lib/postgresql/data"))
                 (environment
-                    ("POSTGRESQL_USERNAME" "postgres")
-                    ("POSTGRESQL_DATABASE" "docuseal")
-                    ("POSTGRESQL_PASSWORD" ,db-password))))))
+                    ("POSTGRES_USER" "postgres")
+                    ("POSTGRES_DB" "docuseal")
+                    ("POSTGRES_PASSWORD" ,db-password))))))

--- a/src/app-store/definitions/flowise/flowise.lisp
+++ b/src/app-store/definitions/flowise/flowise.lisp
@@ -5,13 +5,13 @@
         (containers
             (container
                 (name "db")
-                (image "docker.io/bitnami/postgresql:17")
+                (image "docker.io/library/postgres:17")
                 (volumes
-                    ("postgresql_data" "/bitnami/postgresql"))
+                    ("postgresql_data"  "/var/lib/postgresql/data"))
                 (environment
-                    ("POSTGRESQL_USERNAME" "flowise")
-                    ("POSTGRESQL_DATABASE" "flowise")
-                    ("POSTGRESQL_PASSWORD" ,db-password)))
+                    ("POSTGRES_USER" "flowise")
+                    ("POSTGRES_DB" "flowise")
+                    ("POSTGRES_PASSWORD" ,db-password)))
             (container 
                 (name "flowise")
                 (image "docker.io/flowiseai/flowise:2.1.2")

--- a/src/app-store/definitions/gitea/gitea.lisp
+++ b/src/app-store/definitions/gitea/gitea.lisp
@@ -19,10 +19,10 @@
                     ("GITEA__database__PASSWD" ,db-password)))
             (container
                 (name "postgres")
-                (image "docker.io/bitnami/postgresql:17")
+                (image "docker.io/library/postgres:17")
                 (volumes
-                    ("postgres-data" "/bitnami/postgresql"))
+                    ("postgres-data" "/var/lib/postgresql/data"))
                 (environment
-                    ("POSTGRESQL_USERNAME" ,db-user)
-                    ("POSTGRESQL_DATABASE" ,db-name)
-                    ("POSTGRESQL_PASSWORD" ,db-password))))))
+                    ("POSTGRES_USER" ,db-user)
+                    ("POSTGRES_DB" ,db-name)
+                    ("POSTGRES_PASSWORD" ,db-password))))))

--- a/src/app-store/definitions/keycloak/keycloak.lisp
+++ b/src/app-store/definitions/keycloak/keycloak.lisp
@@ -6,13 +6,13 @@
         (containers
             (container
                 (name "postgres")
-                (image "docker.io/bitnami/postgresql:17")
+                (image "docker.io/library/postgres:17")
                 (volumes
-                    ("psql_data" "/bitnami/postgresql"))
+                    ("psql_data" "/var/lib/postgresql/data"))
                 (environment
-                    ("POSTGRESQL_USERNAME" "keycloak")
-                    ("POSTGRESQL_DATABASE" "keycloak")
-                    ("POSTGRESQL_PASSWORD" ,db-password)))
+                    ("POSTGRES_USER" "keycloak")
+                    ("POSTGRES_DB" "keycloak")
+                    ("POSTGRES_PASSWORD" ,db-password)))
             (container
                 (name "keyclock")
                 (build "localhost/johnaic/keycloak:21.0")

--- a/src/app-store/definitions/langflow/langflow.lisp
+++ b/src/app-store/definitions/langflow/langflow.lisp
@@ -19,10 +19,10 @@
                     ("custom_components" "/app/custom_components")))
             (container
                 (name "postgres")
-                (image "docker.io/bitnami/postgresql:17")
+                (image  "docker.io/library/postgres:17")
                 (volumes
-                    ("langflow-postgres" "/bitnami/postgresql"))
+                    ("langflow-postgres" "/var/lib/postgresql/data"))
                 (environment 
-                    ("POSTGRESQL_PASSWORD" ,db-password)
-                    ("POSTGRESQL_USERNAME" "langflow")
-                    ("POSTGRESQL_DATABASE" "langflow"))))))
+                    ("POSTGRES_PASSWORD" ,db-password)
+                    ("POSTGRES_USER" "langflow")
+                    ("POSTGRES_DB" "langflow"))))))

--- a/src/app-store/definitions/matrix/matrix.lisp
+++ b/src/app-store/definitions/matrix/matrix.lisp
@@ -20,14 +20,14 @@
                     ("POSTGRES_PASSWORD" ,db-password)))
             (container
                 (name "postgres")
-                (image "docker.io/bitnami/postgresql:17")
+                (image "docker.io/library/postgres:17")
                 (volumes
-                    ("postgres-data" "/bitnami/postgresql"))
+                    ("postgres-data" "/var/lib/postgresql/data"))
                 (environment
-                    ("POSTGRESQL_USERNAME" "synapse")
-                    ("POSTGRESQL_DATABASE" "synapse")
-                    ("POSTGRESQL_INITDB_ARGS" "--encoding=UTF-8 --lc-collate=C --lc-ctype=C")
-                    ("POSTGRESQL_PASSWORD" ,db-password)))
+                    ("POSTGRES_USER" "synapse")
+                    ("POSTGRES_DB" "synapse")
+                    ("POSTGRES_INITDB_ARGS" "--encoding=UTF-8 --lc-collate=C --lc-ctype=C")
+                    ("POSTGRES_PASSWORD" ,db-password)))
             (container
                 (name "mautrix-whatsapp")
                 (image "dock.mau.dev/mautrix/whatsapp:v0.11.0")
@@ -40,11 +40,11 @@
                     ("MAUTRIX_POSTGRES_PASSWORD" ,mautrix-db-password)))
             (container
                 (name "mautrix-postgres")
-                (image "docker.io/bitnami/postgresql:17")
+                (image "docker.io/library/postgres:17")
                 (volumes
-                    ("mautrix-pgdata" "/bitnami/postgresql"))
+                    ("mautrix-pgdata" "/var/lib/postgresql/data"))
                 (environment
-                    ("POSTGRESQL_USERNAME" "mautrix")
-                    ("POSTGRESQL_DATABASE" "mautrix")
+                    ("POSTGRES_USER" "mautrix")
+                    ("POSTGRES_DB" "mautrix")
                     ("POSTGRESQL_PORT_NUMBER" "5433")
-                    ("POSTGRESQL_PASSWORD" ,mautrix-db-password))))))
+                    ("POSTGRES_PASSWORD" ,mautrix-db-password))))))

--- a/src/app-store/definitions/paperless-ngx/paperless-ngx.lisp
+++ b/src/app-store/definitions/paperless-ngx/paperless-ngx.lisp
@@ -10,13 +10,13 @@
                     ("redisdata" "/data"))) 
             (container
                 (name "postgresql")
-                (image "docker.io/bitnami/postgresql:17")
+                (image "docker.io/library/postgres:17")
                 (volumes
-                    ("postgresql_data" "/bitnami/postgresql"))
+                    ("postgresql_data" "/var/lib/postgresql/data"))
                 (environment
-                    ("POSTGRESQL_USERNAME" "paperless")
-                    ("POSTGRESQL_DATABASE" "paperless")
-                    ("POSTGRESQL_PASSWORD" ,db-password)))
+                    ("POSTGRES_USER" "paperless")
+                    ("POSTGRES_DB" "paperless")
+                    ("POSTGRES_PASSWORD" ,db-password)))
             (container 
                 (name "webserver")
                 (image "ghcr.io/paperless-ngx/paperless-ngx:2.14.7")

--- a/src/app-store/definitions/shlink/shlink.lisp
+++ b/src/app-store/definitions/shlink/shlink.lisp
@@ -5,13 +5,13 @@
         (containers 
             (container
                 (name "postgresql")
-                (image "docker.io/bitnami/postgresql:17")
+                (image "docker.io/library/postgres:17")
                 (volumes
-                    ("postgresql_data" "/bitnami/postgresql"))
+                    ("postgresql_data" "/var/lib/postgresql/data"))
                 (environment
-                    ("POSTGRESQL_USERNAME" "shlink")
-                    ("POSTGRESQL_DATABASE" "shlink")
-                    ("POSTGRESQL_PASSWORD" ,db-password)))
+                    ("POSTGRES_USER" "shlink")
+                    ("POSTGRES_DB" "shlink")
+                    ("POSTGRES_PASSWORD" ,db-password)))
             (container 
                 (name "shlink")
                 (image "docker.io/shlinkio/shlink:4.5.2")

--- a/src/app-store/definitions/vikunja/vikunja.lisp
+++ b/src/app-store/definitions/vikunja/vikunja.lisp
@@ -6,13 +6,13 @@
         (containers
             (container
                 (name "db")
-                (image "docker.io/bitnami/postgresql:17")
+                (image "docker.io/library/postgres:17")
                 (volumes
-                    ("psql_data" "/bitnami/postgresql"))
+                    ("psql_data" "/var/lib/postgresql/data"))
                 (environment
-                    ("POSTGRESQL_USERNAME" "vikunja")
-                    ("POSTGRESQL_DATABASE" "vikunja")
-                    ("POSTGRESQL_PASSWORD" ,db-password)))
+                    ("POSTGRES_USER" "vikunja")
+                    ("POSTGRES_DB" "vikunja")
+                    ("POSTGRES_PASSWORD" ,db-password)))
             (container
                 (name "vikunja")
                 (image "docker.io/vikunja/vikunja:0.24.6")


### PR DESCRIPTION
Replaced Bitnami containers in some applications:
- docuseal
- gitea
- keycloak
- matrix
- paperless-ngx
- shlink
- vikunja
- langflow
- flowise

Changes:
- Migrated PostgreSQL to docker.io/library/postgres:17
- Migrated Redis to official redis image i.e docker.io/library/redis:7
- Updated environment variables (POSTGRESQL  to POSTGRES)
- Updated volume paths from /bitnami to standard container paths

Verification:
- podman pull docker.io/library/postgres:17 works
- Tested installation using johnny install paperless-ngx