### PR TITLE
Add OpenClaw app definition (Mattermost AI bot)

### DIFF
--- a/src/app-store/definitions/openclaw/Containerfile
+++ b/src/app-store/definitions/openclaw/Containerfile
@@ -1,0 +1,22 @@
+FROM ghcr.io/openclaw/openclaw:2026.3.24
+
+USER root
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    sudo \
+    python3-pip \
+    jq \
+    pandoc \
+    ffmpeg \
+    sqlite3 \
+    ripgrep \
+    fd-find \
+    texlive-latex-base \
+    texlive-latex-extra \
+    texlive-fonts-recommended \
+    texlive-latex-recommended \
+    && rm -rf /var/lib/apt/lists/* \
+    && echo 'node ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/node \
+    && chmod 440 /etc/sudoers.d/node
+
+USER node

--- a/src/app-store/definitions/openclaw/init.sh
+++ b/src/app-store/definitions/openclaw/init.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Generate openclaw.json from environment variables on first run.
+# Skips if config already exists (preserves user edits on reinstall).
+
+set -e
+
+CONFIG_DIR="/config"
+CONFIG_FILE="$CONFIG_DIR/openclaw.json"
+
+if [ -f "$CONFIG_FILE" ]; then
+    echo "Config already exists at $CONFIG_FILE — skipping generation."
+    exit 0
+fi
+
+echo "Generating $CONFIG_FILE from install inputs..."
+
+cat > "$CONFIG_FILE" <<CONF
+{
+  "gateway": {
+    "mode": "local",
+    "bind": "lan",
+    "controlUi": {
+      "dangerouslyAllowHostHeaderOriginFallback": true
+    },
+    "auth": {
+      "mode": "token",
+      "token": "${GATEWAY_TOKEN}"
+    }
+  },
+  "env": {
+    "GEMINI_API_KEY": "${LLM_API_KEY}"
+  },
+  "models": {
+    "mode": "merge",
+    "providers": {
+      "google": {
+        "baseUrl": "https://generativelanguage.googleapis.com/v1beta",
+        "models": [
+          {
+            "id": "gemini-3-flash-preview",
+            "name": "gemini-3-flash-preview",
+            "reasoning": true,
+            "contextWindow": 1048576,
+            "maxTokens": 8192
+          }
+        ]
+      }
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "google/gemini-3-flash-preview"
+      },
+      "thinkingDefault": "medium",
+      "models": {
+        "google/gemini-3-flash-preview": {
+          "params": {
+            "maxTokens": 16384
+          }
+        }
+      }
+    }
+  },
+  "channels": {
+    "mattermost": {
+      "enabled": true,
+      "botToken": "${MATTERMOST_BOT_TOKEN}",
+      "baseUrl": "${MATTERMOST_URL}",
+      "dmPolicy": "open",
+      "allowFrom": ["*"],
+      "chatmode": "onmessage"
+    }
+  },
+  "plugins": {
+    "entries": {
+      "mattermost": {
+        "enabled": true
+      }
+    }
+  }
+}
+CONF
+
+echo "Config written to $CONFIG_FILE"
+
+# Ensure workspace and state dirs have correct ownership (node = uid 1000)
+chown -R 1000:1000 /home/openclaw/workspace 2>/dev/null || true
+chown -R 1000:1000 /home/node/.openclaw 2>/dev/null || true

--- a/src/app-store/definitions/openclaw/openclaw.lisp
+++ b/src/app-store/definitions/openclaw/openclaw.lisp
@@ -1,0 +1,40 @@
+; OpenClaw — AI assistant bot for Mattermost
+; Connects to an existing Mattermost instance via websocket.
+; The gateway control UI is exposed on port 18789.
+
+(define-app
+    (version "2026.3.24")
+    (ports 18789)
+    (url "https://github.com/openclaw/openclaw")
+    (let ((gateway-token ,(gen-password))
+          (mattermost-url ,(interactive-input "Mattermost URL"
+              "Base URL of your Mattermost server. Example: https://mattermost.example.com"))
+          (mattermost-bot-token ,(interactive-input "Mattermost bot token"
+              "Create a bot account in Mattermost (Integrations > Bot Accounts) and paste the token here."))
+          (llm-api-key ,(interactive-input "LLM API key"
+              "API key for the LLM provider (Gemini by default). Example: your Gemini API key from https://aistudio.google.com/apikey")))
+        (containers
+            (container
+                (name "init")
+                (image "docker.io/library/ubuntu:22.04")
+                (command "bash /mnt/init.sh")
+                (volumes
+                    ("config" "/config")
+                    ("workspace" "/home/openclaw/workspace")
+                    ("state" "/home/node/.openclaw")
+                    ("init.sh" "/mnt/init.sh"))
+                (environment
+                    ("MATTERMOST_URL" ,mattermost-url)
+                    ("MATTERMOST_BOT_TOKEN" ,mattermost-bot-token)
+                    ("LLM_API_KEY" ,llm-api-key)
+                    ("GATEWAY_TOKEN" ,gateway-token)))
+            (container
+                (name "openclaw")
+                (build "localhost/johnaic/openclaw:2026.3.24")
+                (volumes
+                    ("config" "/config")
+                    ("workspace" "/home/openclaw/workspace")
+                    ("state" "/home/node/.openclaw"))
+                (environment
+                    ("OPENCLAW_CONFIG_PATH" "/config/openclaw.json")
+                    ("OPENCLAW_GATEWAY_TOKEN" ,gateway-token))))))


### PR DESCRIPTION
## Summary

- Adds a new app definition for [OpenClaw](https://github.com/openclaw/openclaw), an AI assistant bot that connects to an existing Mattermost instance via websocket
- Custom-built image extends the official OpenClaw image with extra tools (pandoc, ffmpeg, LaTeX, ripgrep, sqlite3, jq)
- Uses `interactive-input` to prompt for Mattermost URL, bot token, and LLM API key at install time
- Init container generates `openclaw.json` from those inputs on first run; preserves user edits on reinstall
- Gateway control UI exposed on port 18789

## Files

| File | Purpose |
|------|---------|
| `openclaw.lisp` | App definition — init container + main OpenClaw container |
| `Containerfile` | Extends `ghcr.io/openclaw/openclaw:2026.3.24` with extra tools |
| `init.sh` | First-run config generation from install-time inputs |

## Test plan

- [ ] `johnny install openclaw` — prompts for Mattermost URL, bot token, LLM API key
- [ ] Config generated at `~/.johnny/openclaw/config/openclaw.json` with correct values
- [ ] Container builds and connects to Mattermost as a bot
- [ ] Reinstall preserves existing config (no overwrite)
- [ ] `johnny status openclaw` shows running

🤖 Generated with [Claude Code](https://claude.com/claude-code)