### PR TITLE
Update n8n app version to 2.17.0

### DIFF
--- a/src/app-store/definitions/n8n/n8n.lisp
+++ b/src/app-store/definitions/n8n/n8n.lisp
@@ -25,7 +25,7 @@
                     ("init_worker.sh" "/mnt/init_worker.sh")))
             (container
                 (name "n8n")
-                (image "docker.io/n8nio/n8n:1.123.11")
+                (image "docker.io/n8nio/n8n:2.17.0")
                 (volumes
                     ("n8n_storage" "/home/node/.n8n"))
                 (environment


### PR DESCRIPTION
### Update n8n app version

- Updated n8n image version from `1.123.11` to `2.17.0`
- Verified that the application installs and runs successfully
- Tested workflow execution (Manual Trigger + Set node)
- Confirmed database connectivity and data persistence