### PR TITLE
Update ollama version

### DIFF
--- a/src/app-store/definitions/open-webui/open-webui.lisp
+++ b/src/app-store/definitions/open-webui/open-webui.lisp
@@ -6,7 +6,7 @@
         (containers
             (container
                 (name "ollama")
-                (image "docker.io/ollama/ollama:0.19.0")
+                (image "docker.io/ollama/ollama:0.20.3")
                 (volumes
                     ("models" "/root/.ollama"))
                 (additional-flags "--device nvidia.com/gpu=all"))

--- a/src/app-store/definitions/open-webui/open-webui.lisp
+++ b/src/app-store/definitions/open-webui/open-webui.lisp
@@ -6,7 +6,7 @@
         (containers
             (container
                 (name "ollama")
-                (image "docker.io/ollama/ollama:0.11.10")
+                (image "docker.io/ollama/ollama:0.19.0")
                 (volumes
                     ("models" "/root/.ollama"))
                 (additional-flags "--device nvidia.com/gpu=all"))


### PR DESCRIPTION
### Update Ollama version in open-webui

- Updated Ollama image version from `0.11.10` to `0.20.3`
- Verified that the application runs successfully with the updated version